### PR TITLE
fix Dictionary and DictionaryIterator memory leaks

### DIFF
--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -843,21 +843,6 @@ void InitThingdef()
 	wbplayerstruct->Size = sizeof(wbplayerstruct_t);
 	wbplayerstruct->Align = alignof(wbplayerstruct_t);
 
-	auto dictionarystruct = NewStruct("Dictionary", nullptr, true);
-	dictionarystruct->Size = sizeof(Dictionary);
-	dictionarystruct->Align = alignof(Dictionary);
-	NewPointer(dictionarystruct, false)->InstallHandlers(
-		[](FSerializer &ar, const char *key, const void *addr)
-		{
-			ar(key, *(Dictionary **)addr);
-		},
-		[](FSerializer &ar, const char *key, void *addr)
-		{
-			Serialize<Dictionary>(ar, key, *(Dictionary **)addr, nullptr);
-			return true;
-		}
-	);
-
 	FAutoSegIterator probe(CRegHead, CRegTail);
 
 	while (*++probe != NULL)

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -2165,7 +2165,7 @@ template<> FSerializer &Serialize(FSerializer &arc, const char *key, FFont *&fon
 FString DictionaryToString(const Dictionary &dict)
 {
 	Dictionary::ConstPair *pair;
-	Dictionary::ConstIterator i { dict };
+	Dictionary::ConstIterator i { dict.Map };
 
 	rapidjson::StringBuffer buffer;
 	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -2214,7 +2214,7 @@ Dictionary *DictionaryFromString(const FString &string)
 			return dict;
 		}
 
-		dict->Insert(i->name.GetString(), i->value.GetString());
+		dict->Map.Insert(i->name.GetString(), i->value.GetString());
 	}
 
 	return dict;

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -2190,7 +2190,7 @@ Dictionary *DictionaryFromString(const FString &string)
 		return nullptr;
 	}
 
-	Dictionary *const dict = new Dictionary;
+	Dictionary *const dict = Create<Dictionary>();
 
 	if (string.IsEmpty())
 	{

--- a/src/utility/dictionary.cpp
+++ b/src/utility/dictionary.cpp
@@ -42,7 +42,7 @@ void Dictionary::Serialize(FSerializer &arc)
 		// Receive new Dictionary, copy contents, clean up.
 		Dictionary *pointerToDeserializedDictionary;
 		arc(key, pointerToDeserializedDictionary);
-		TransferFrom(*pointerToDeserializedDictionary);
+		Map.TransferFrom(pointerToDeserializedDictionary->Map);
 		delete pointerToDeserializedDictionary;
 	}
 }
@@ -56,12 +56,12 @@ static Dictionary *DictCreate()
 
 static void DictInsert(Dictionary *dict, const FString &key, const FString &value)
 {
-	dict->Insert(key, value);
+	dict->Map.Insert(key, value);
 }
 
 static void DictAt(const Dictionary *dict, const FString &key, FString *result)
 {
-	const FString *value = dict->CheckKey(key);
+	const FString *value = dict->Map.CheckKey(key);
 	*result = value ? *value : "";
 }
 
@@ -72,7 +72,7 @@ static void DictToString(const Dictionary *dict, FString *result)
 
 static void DictRemove(Dictionary *dict, const FString &key)
 {
-	dict->Remove(key);
+	dict->Map.Remove(key);
 }
 
 //=====================================================================================
@@ -150,7 +150,7 @@ void DictionaryIterator::Serialize(FSerializer &arc)
 
 void DictionaryIterator::init(Dictionary *dict)
 {
-	Iterator = std::make_unique<Dictionary::ConstIterator>(*dict);
+	Iterator = std::make_unique<Dictionary::ConstIterator>(dict->Map);
 	Dict = dict;
 
 	GC::WriteBarrier(this, Dict);

--- a/src/utility/dictionary.h
+++ b/src/utility/dictionary.h
@@ -13,13 +13,19 @@
  *
  * It is derived from DObject to be a part of normal GC process.
  */
-class Dictionary final : public DObject, public TMap<FString, FString>
+class Dictionary final : public DObject
 {
 	DECLARE_CLASS(Dictionary, DObject)
 
 public:
 
+	using StringMap = TMap<FString, FString>;
+	using ConstIterator = StringMap::ConstIterator;
+	using ConstPair = StringMap::ConstPair;
+
 	void Serialize(FSerializer &arc) override;
+
+	StringMap Map;
 };
 
 /**
@@ -45,7 +51,7 @@ public:
 	 */
 	DictionaryIterator();
 
-    void Serialize(FSerializer &arc) override;
+	void Serialize(FSerializer &arc) override;
 
 	/**
 	 * @brief init function complements constructor.

--- a/src/utility/dictionary.h
+++ b/src/utility/dictionary.h
@@ -2,13 +2,63 @@
 
 #include "tarray.h"
 #include "zstring.h"
+#include "dobject.h"
 
-using Dictionary = TMap<FString, FString>;
+#include <memory>
 
-struct DictionaryIterator
+/**
+ * @brief The Dictionary class exists to be exported to ZScript.
+ *
+ * It is a string-to-string map.
+ *
+ * It is derived from DObject to be a part of normal GC process.
+ */
+class Dictionary final : public DObject, public TMap<FString, FString>
 {
-	explicit DictionaryIterator(const Dictionary &dict);
+	DECLARE_CLASS(Dictionary, DObject)
 
-	Dictionary::ConstIterator Iterator;
+public:
+
+	void Serialize(FSerializer &arc) override;
+};
+
+/**
+ * @brief The DictionaryIterator class exists to be exported to ZScript.
+ *
+ * It provides iterating over a Dictionary. The order is not specified.
+ *
+ * It is derived from DObject to be a part of normal GC process.
+ */
+class DictionaryIterator final : public DObject
+{
+	DECLARE_CLASS(DictionaryIterator, DObject)
+	HAS_OBJECT_POINTERS
+
+public:
+
+	~DictionaryIterator() override = default;
+
+	/**
+	 * IMPLEMENT_CLASS macro needs a constructor without parameters.
+	 *
+	 * @see init().
+	 */
+	DictionaryIterator();
+
+    void Serialize(FSerializer &arc) override;
+
+	/**
+	 * @brief init function complements constructor.
+	 * @attention always call init after constructing DictionaryIterator.
+	 */
+	void init(Dictionary *dict);
+
+	std::unique_ptr<Dictionary::ConstIterator> Iterator;
 	Dictionary::ConstPair *Pair;
+
+	/**
+	 * @brief Dictionary attribute exists for holding a pointer to iterated
+	 * dictionary, so it is known by GC.
+	 */
+	Dictionary *Dict;
 };

--- a/src/version.h
+++ b/src/version.h
@@ -84,7 +84,7 @@ const char *GetVersionString();
 #define SAVEGAME_EXT "zds"
 
 // MINSAVEVER is the minimum level snapshot version that can be loaded.
-#define MINSAVEVER 4558
+#define MINSAVEVER 4556
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.

--- a/src/version.h
+++ b/src/version.h
@@ -84,11 +84,11 @@ const char *GetVersionString();
 #define SAVEGAME_EXT "zds"
 
 // MINSAVEVER is the minimum level snapshot version that can be loaded.
-#define MINSAVEVER	4556
+#define MINSAVEVER 4558
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4557
+#define SAVEVER 4558
 
 // This is so that derivates can use the same savegame versions without worrying about engine compatibility
 #define GAMESIG "GZDOOM"

--- a/wadsrc/static/zscript/dictionary.zs
+++ b/wadsrc/static/zscript/dictionary.zs
@@ -1,4 +1,11 @@
-struct Dictionary native
+/**
+ * Dictionary provides key-value storage.
+ *
+ * Both keys and values are strings.
+ *
+ * @note keys are case-sensitive.
+ */
+class Dictionary
 {
 	native static Dictionary Create();
 
@@ -23,7 +30,15 @@ struct Dictionary native
 	native String ToString() const;
 }
 
-struct DictionaryIterator native
+/**
+ * Provides iterating over a Dictionary.
+ *
+ * Order is not specified.
+ *
+ * DictionaryIterator is not serializable. To make DictionaryIterator a class
+ * member, use `transient` keyword.
+ */
+class DictionaryIterator
 {
 	native static DictionaryIterator Create(Dictionary dict);
 


### PR DESCRIPTION
The gist of the commit is that Dictionary and DictionaryIterator now inherit from DObject. Serialization is moved from struct code to class.

Notes:

1. Savegame version is bumped, because Dictionary serialization is switched from struct to class.
2. I'm not sure about GC::WriteBarrier. I believe it's needed in DictionaryIterator::init because Dictionary can be potentially be marked for removal. Maybe it's needed in other places, maybe it's not needed at all.
3. Added some documentation to ZScript Dictionary and DictionaryIterator classes.
4. Serialization of DictionaryIterator is explicitly disabled.